### PR TITLE
remove single space in interpreter declaration

### DIFF
--- a/bin/check-memcached-stats.rb
+++ b/bin/check-memcached-stats.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 #
 #   check-memcached-stats
 #

--- a/bin/metrics-memcached-graphite.rb
+++ b/bin/metrics-memcached-graphite.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 #
 #   memcached-graphite
 #

--- a/bin/metrics-memcached-key-stats-graphite.rb
+++ b/bin/metrics-memcached-key-stats-graphite.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 #
 #   memcached-key-stats-graphite
 #

--- a/bin/metrics-memcached-socket-graphite.rb
+++ b/bin/metrics-memcached-socket-graphite.rb
@@ -1,4 +1,4 @@
-#! /usr/bin/env ruby
+#!/usr/bin/env ruby
 #
 #   memcached-socket-graphite
 #


### PR DESCRIPTION
Removed space between the sha-bang and path to the interpreter.
