### PR TITLE
remove memcached gem

### DIFF
--- a/bin/metrics-memcached-graphite.rb
+++ b/bin/metrics-memcached-graphite.rb
@@ -59,7 +59,7 @@ class MemcachedGraphite < Sensu::Plugin::Metric::CLI::Graphite
         socket.print "stats\r\n"
         socket.close_write
         socket.read.each_line do |line|
-          _, k, v = line.strip.split(" ", 3)
+          _, k, v = line.strip.split(' ', 3)
           next unless k
 
           output "#{config[:scheme]}.#{k}", v

--- a/sensu-plugins-memcached.gemspec
+++ b/sensu-plugins-memcached.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsMemcached::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'memcached',    '1.8.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
Long story short, I've been dealing with sensu-plugins/sensu-plugins-memcached#4 for a long time and I finally got frustrated enough to see if I could fix it. I went and looked at the code and discovered that the memcached gem was only used in a single place and for something very trivial, so I decided to remove it. A C extension for a single call to `stats` is wayyyyyy too much, and it's obviously causing issues.

It wasn't until after I did that I discovered that there's already a script called `metrics-memcached-socket-graphite.rb` that does the same thing, but I looked at it and it's ... kind of doing a lot of extra stuff that's not really necessary? If you decide to accept this PR, I'd suggest removing that script.

I also wrote a second patch which replaces memcached with [Dalli](https://github.com/petergoldstein/dalli), in case y'all want to stick with a library. PR for that is #8.