### PR TITLE
replace memcached gem with dalli

### DIFF
--- a/bin/metrics-memcached-graphite.rb
+++ b/bin/metrics-memcached-graphite.rb
@@ -30,7 +30,7 @@
 #
 
 require 'sensu-plugin/metric/cli'
-require 'memcached'
+require 'dalli'
 require 'socket'
 
 class MemcachedGraphite < Sensu::Plugin::Metric::CLI::Graphite
@@ -54,9 +54,11 @@ class MemcachedGraphite < Sensu::Plugin::Metric::CLI::Graphite
          default: "#{::Socket.gethostname}.memcached"
 
   def run
-    cache = Memcached.new("#{config[:host]}:#{config[:port]}")
+    cache = Dalli::Client.new("#{config[:host]}:#{config[:port]}")
 
-    cache.stats.each do |k, v|
+    # cache.stats returns a hash of server => stats. Since we only have one
+    # server, we can just grab the first value and iterate over that.
+    cache.stats.values.first.each do |k, v|
       output "#{config[:scheme]}.#{k}", v
     end
 

--- a/sensu-plugins-memcached.gemspec
+++ b/sensu-plugins-memcached.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.version                = SensuPluginsMemcached::Version::VER_STRING
 
   s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
-  s.add_runtime_dependency 'memcached',    '1.8.0'
+  s.add_runtime_dependency 'dalli',        '~> 2.7'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
This is an alternative to sensu-plugins/sensu-plugins-memcached#7 which replaces memcached gem with the pure-ruby [dalli](https://github.com/petergoldstein/dalli). See that PR for the details and background.